### PR TITLE
Bug fix into project_benchmark.py + Add project_benchmark_report.py

### DIFF
--- a/project_benchmark.py
+++ b/project_benchmark.py
@@ -247,6 +247,9 @@ def preprocess(
         )
         for data in pandas.Series(df.input_size_mb.explode())
     ]
+    
+    # Replace mem_mb by mem_gb if mem_gb is not NaN (because if mem_gb is used in rule, mem_mb takes the default value which is wrong)
+    df.loc[df["mem_gb"].notna(), "mem_mb"] = df["mem_gb"] * 1000
 
     # Efficiency
     df["efficiency"] = [

--- a/project_benchmark.py
+++ b/project_benchmark.py
@@ -99,7 +99,6 @@ def describe_rule(
         tmp = df[df["rule_name"] == rule_name].copy()
     else:
         tmp = df.copy()
-    tmp = tmp.describe()
 
     return {
         "mean_time": mean_time(tmp),

--- a/project_benchmark.py
+++ b/project_benchmark.py
@@ -10,7 +10,7 @@ import sys
 from functools import partial
 from rich.console import Console
 from pathlib import Path
-
+from numpy import isnan
 
 def hhmmss(seconds: int | float) -> str:
     """
@@ -27,7 +27,6 @@ def nb(number: str | int | float) -> str:
         return f"{number:.2f}"
     return round(number, 2)
 
-
 def extract_text(
     df: pandas.DataFrame,
     colname: str,
@@ -41,28 +40,31 @@ def extract_text(
     """
     desc = df[[colname]].describe()
     val = nb(desc.loc[val][colname])
-    if (colname == "s") and (not seconds):
-        val = hhmmss(val)
-    elif colname == "runtime":
-        if seconds is True:
-            val = val * 60
-        else:
-            val = hhmmss(val * 60)
-
-    std = ""
-    if with_std is True:
-        std = nb(desc.loc["std"][colname])
+    if not isnan(val):
         if (colname == "s") and (not seconds):
-            std = hhmmss(std)
+            val = hhmmss(val)
         elif colname == "runtime":
             if seconds is True:
-                std = std * 60
+                val = val * 60
             else:
-                std = hhmmss(std * 60)
-    if std != "":
-        std = f"± {std}"
+                val = hhmmss(val * 60)
 
-    return f"""{val} {std} {unit}""".strip()
+        std = ""
+        if with_std is True and not isnan(desc.loc["std"][colname]):
+            std = nb(desc.loc["std"][colname])
+            if (colname == "s") and (not seconds):
+                std = hhmmss(std)
+            elif colname == "runtime":
+                if seconds is True:
+                    std = std * 60
+                else:
+                    std = hhmmss(std * 60)
+        if std != "":
+            std = f"± {std}"
+
+        return f"""{val} {std} {unit}""".strip()
+    else:
+    	return f""""""
 
 
 mean_time = partial(extract_text, colname="s", unit="")
@@ -100,6 +102,11 @@ def describe_rule(
     else:
         tmp = df.copy()
 
+    if time_at_most(tmp, seconds=True) != "" and reserved_runtime(tmp, seconds=True) != "":
+        time_efficiency = nb(100 * float(time_at_most(tmp, seconds=True)) / max(float(reserved_runtime(tmp, seconds=True)), 1))
+    else:
+        time_efficiency = ""
+
     return {
         "mean_time": mean_time(tmp),
         "mean_reserved_mib": mean_mib_reserved(tmp),
@@ -110,11 +117,7 @@ def describe_rule(
         "mean_memory_wasted": memory_wasted(tmp),
         "mean_efficiency": efficiency(tmp),
         "reserved_runtime": reserved_runtime(tmp),
-        "time_efficiency": nb(
-            100
-            * float(time_at_most(tmp, seconds=True))
-            / max(float(reserved_runtime(tmp, seconds=True)), 1)
-        ),
+        "time_efficiency": time_efficiency,
     }
 
 
@@ -246,7 +249,7 @@ def preprocess(
         )
         for data in pandas.Series(df.input_size_mb.explode())
     ]
-    
+
     # Replace mem_mb by mem_gb if mem_gb is not NaN (because if mem_gb is used in rule, mem_mb takes the default value which is wrong)
     df.loc[df["mem_gb"].notna(), "mem_mb"] = df["mem_gb"] * 1000
 

--- a/project_benchmark_report.py
+++ b/project_benchmark_report.py
@@ -1,0 +1,212 @@
+import pandas as pd
+import matplotlib.pyplot as plt
+import base64
+import io
+import argparse
+import ast
+from pathlib import Path
+import numpy as np
+from datetime import timedelta
+
+# ========== CONFIG ==========
+metrics_to_plot = ['mem_mb', 'max_rss', 'max_vms', 'wasted', 'efficiency', 'threads', 'cpu_time',
+    'cpu_usage', 'mean_load', 'time_min', 's', 'runtime_seconds']
+
+# Définitions des métriques (https://snakemake.readthedocs.io/en/stable/snakefiles/rules.html#benchmark-rules)
+metric_definitions = {
+    "mem_mb": "Reserved memory (in MB).",
+    "max_rss": "Maximum physical memory used (Resident Set Size), in MB.",
+    "max_vms": "Maximum virtual memory used (Virtual Memory Size), in MB.",
+    "wasted": "Reserved but unused memory (wasted) based on Maximum virtual memory, in MB.",
+    "efficiency": "Proportion of reserved memory actually used, based on Maximum virtual memory, in %.",
+    "threads": "Number of reserved threads.",
+    "cpu_time": "Total CPU time consumed (sum across all cores; user + system), in seconds.",
+    "cpu_usage": "Percentage of CPU used, in %.",
+    "mean_load": "CPU load = CPU time (cpu_usage) divided by wall clock time ('s').",
+    "time_min": "Reserved time for a job, in minutes.",
+    "s": "Execution duration, in seconds.",
+    "runtime_seconds": "Actual execution duration, converted from h:m:s to seconds.",
+    "io_in": "Total volume of data read by the job, in bytes.",
+    "io_out": "Total volume of data written by the job, in bytes.",
+    "input_size_mb": "Size of input files, in MB."
+}
+
+# ========== Fonctions utilitaires ==========
+def hms_to_seconds(hms):
+    try:
+        t = str(hms)
+        if ":" in t:
+            h, m, s = t.split(":")
+            return int(h)*3600 + int(m)*60 + float(s)
+        return float(t)
+    except:
+        return None
+        
+def fmt_seconds(sec):
+    if pd.isna(sec):
+        return ""
+    return str(timedelta(seconds=int(round(float(sec)))))
+
+def build_group_stats(df):
+    time_col = "s" if "s" in df.columns else ("hms_seconds" if "hms_seconds" in df.columns else None)
+    agg_map = {"jobid": "count"}
+
+    for c in ["max_rss","max_vms","mem_mb","wasted","efficiency","threads","cpu_time","cpu_usage","mean_load","time_min"]:
+        if c in df.columns: agg_map[c] = "mean"
+    if time_col:
+        agg_map[time_col] = ["sum","min","max"]
+
+    grouped = df.groupby("rule_name", dropna=False).agg(agg_map)
+    # Flatten MultiIndex columns
+    new_cols = []
+    for col in grouped.columns.values:
+        if isinstance(col, tuple):
+            label = " (".join([str(c) for c in col if c is not None]) + ")"
+        else:
+            label = str(col)
+        new_cols.append(label.strip("_"))
+    grouped.columns = new_cols
+
+    grouped = grouped.rename(columns={"jobid_count":"nb_jobs"}).reset_index()
+
+    if time_col:
+        for sub in ["sum","min","max"]:
+            col = f"{time_col} ({sub})"
+            if col in grouped.columns:
+                grouped[f"{time_col} ({sub} hms)"] = grouped[col].apply(fmt_seconds)
+                grouped.drop(columns=[col], inplace=True)
+
+    #sort_cols = [c for c in [f"{time_col} (sum)","cpu_time (sum)","io_in (sum)"] if c in grouped.columns]
+    #if sort_cols:
+    #    grouped = grouped.sort_values(sort_cols[0], ascending=False)
+    return grouped
+
+def plot_metric(metric, df, group_col="rule_name"):
+    fig, ax = plt.subplots(figsize=(12,4))
+    for name, group in df.groupby(group_col):
+        ax.plot(group.index, group[metric], marker="o", linestyle="-", label=name)
+    ax.set_title(metric)
+    ax.set_xlabel("")
+    ax.set_ylabel(metric)
+    ax.grid(True, linestyle="--", alpha=0.5)
+    ax.legend(bbox_to_anchor=(1.05, 1), loc='upper left')  # légende externe
+    ax.set_xticklabels([]) #masque les valeurs de l'axe des x
+    fig.tight_layout()
+    
+    buf = io.BytesIO()
+    plt.savefig(buf, format="png", bbox_inches="tight")
+    plt.close(fig)
+    return base64.b64encode(buf.getvalue()).decode()
+
+# ========== Main ==========
+def main():
+    parser = argparse.ArgumentParser(description="Génère un rapport HTML avec stats + graphes par règle.")
+    parser.add_argument("input_csv", help="Fichier CSV en entrée")
+    parser.add_argument("-o", "--output_html", default="rapport_stats.html", help="Fichier HTML de sortie")
+    args = parser.parse_args()
+
+    # Lecture CSV
+    df = pd.read_csv(args.input_csv)
+    df.columns = [str(c).strip() for c in df.columns]
+    if "rule_name" not in df.columns:
+        raise SystemExit("Colonne 'rule_name' absente du CSV.")
+
+    # Conversion durées
+    df["runtime_seconds"] = df["h:m:s"].apply(hms_to_seconds)
+
+    # Conversion numérique
+    for col in ["s", "max_rss", "max_vms","io_in", "io_out","mean_load","cpu_time","threads",
+        "cpu_usage","input_size_mb", "efficiency","mem_mb","mem_gb", "wasted", "runtime"]:
+        df[col] = pd.to_numeric(df[col], errors="coerce")
+
+    # Assemblage de time_min, walltime et/ou runtime dans la colonne time_min
+    df["time_min"] = df["time_min"].fillna(df["walltime"])
+    df.drop(columns=["walltime"], inplace=True)
+    df["time_min"] = df["time_min"].fillna(df["runtime"])
+    df.drop(columns=["runtime"], inplace=True)
+
+    # Assemblage de mem_mb et mem_gb dans la colonne mem_mb
+    df["mem_mb"] = df["mem_mb"].fillna(df["mem_gb"] * 1024)
+    df.drop(columns=["mem_gb"], inplace=True)
+    
+    # Supprimer la colonne index
+    df.drop(columns=["index"], inplace=True)
+    df.drop(columns=["index.1"], inplace=True)
+    
+    # Ordonne les colonnes:
+    df = df[['rule_name', 'wildcards', 'mem_mb', 'max_rss', 'max_vms', 'wasted', 'efficiency',
+        'threads', 'cpu_time', 'cpu_usage', 'mean_load', 'time_min', 's', 'runtime_seconds', 
+        'input_size_mb', 'io_in', 'io_out', 'jobid', 'max_uss', 'max_pss', 'params', 'resources']]
+    
+    # Agrégation par règle
+    summary = build_group_stats(df) #.reset_index()
+    
+    # HTML
+    css = '''
+    <style>
+        body { font-family: system-ui, -apple-system, Segoe UI, Roboto, Helvetica, Arial, sans-serif; margin: 2rem; }
+        h1 { margin-bottom: 0; }
+        .subtitle { color: #666; margin-top: .25rem; }
+        table { border-collapse: collapse; width: 100%; margin: 1rem 0 2rem; font-size: 0.95rem; }
+        th, td { border: 1px solid #ddd; padding: .5rem .6rem; text-align: right; }
+        th { background: #f5f5f7; position: sticky; top: 0; }
+        td:first-child, th:first-child { text-align: left; }
+        .pill { display: inline-block; background: #eef; color: #223; padding: .15rem .5rem; border-radius: 999px; font-size: .8rem; }
+        .rule-section { margin-top: 2rem; }
+        .kpi { display: inline-block; padding: .75rem 1rem; background: #fafafa; border: 1px solid #eee; border-radius: .75rem; margin-right: .75rem; }
+        .muted { color: #777; }
+        .small { font-size: .85rem; }
+    </style>
+    '''
+    html_parts = ["<html><head><meta charset='utf-8'><title>Report of benchmark</title>", css, "</head><body>"]
+    html_parts.append("<html><head><meta charset='utf-8'><title>Report Stats</title></head><body>")
+    html_parts.append("<h1>Statistical report on snakemake pipeline execution</h1>")
+    
+    #Cellules de résumer: nombre total de cpu, etc
+    total_cpu = df["cpu_time"].sum() if "cpu_time" in df.columns else np.nan
+    total_io_in = df["io_in"].sum() if "io_in" in df.columns else np.nan
+    total_io_out = df["io_out"].sum() if "io_out" in df.columns else np.nan
+    kpi_html = "<div>"
+    kpi_html += f'<div class="kpi"><div class="muted small">Number of unique rules</div><div><strong>{summary.shape[0]}</strong></div></div>'
+    kpi_html += f'<div class="kpi"><div class="muted small">Number of jobs</div><div><strong>{df.shape[0]}</strong></div></div>'
+    if not pd.isna(total_cpu):
+        kpi_html += f'<div class="kpi"><div class="muted small">Total CPU time (sec)</div><div><strong>{total_cpu:,.0f}s</strong></div></div>'
+    if not pd.isna(total_io_in):
+        kpi_html += f'<div class="kpi"><div class="muted small">Total IO in (octets)</div><div><strong>{total_io_in:,.2f}</strong></div></div>'
+    if not pd.isna(total_io_out):
+        kpi_html += f'<div class="kpi"><div class="muted small">Total IO out (octets)</div><div><strong>{total_io_out:,.2f}</strong></div></div>'
+    kpi_html += "</div>"
+    html_parts.append(kpi_html)
+
+    # Définitions
+    html_parts.append("<h2>Mettrics definition</h2><ul>")
+    for metric, desc in metric_definitions.items():
+        html_parts.append(f"<li><b>{metric}</b> : {desc}</li>")
+    html_parts.append("</ul>")
+
+    # Tableau résumé
+    html_parts.append("<h2>Summary per rule</h2>")
+    html_parts.append(summary.to_html(index=False, float_format="%.2f"))
+
+    # Graphiques
+    html_parts.append("<h2>Graphs per metric</h2>")
+    for metric in metrics_to_plot:
+        img_b64 = plot_metric(metric, df)
+        html_parts.append(f"<img src='data:image/png;base64,{img_b64}'/>")
+
+    # Détails
+    html_parts.append("<h2>Details per rule</h2>")
+    for rule in df["rule_name"].unique():
+        html_parts.append(f"<h3>{rule}</h3>")
+        sub_df = df[df["rule_name"] == rule]
+        html_parts.append(sub_df.to_html(index=False, float_format="%.2f"))
+
+    html_parts.append("</body></html>")
+
+    with open(args.output_html, "w", encoding="utf-8") as f:
+        f.write("\n".join(html_parts))
+
+    print(f"HTML report generated : {args.output_html}")
+
+if __name__ == "__main__":
+    main()

--- a/snakemake_benchmark_summary.yml
+++ b/snakemake_benchmark_summary.yml
@@ -1,0 +1,54 @@
+name: /home/m_aglave/.environnements_conda/snakemake_benchmark_summary
+channels:
+  - conda-forge
+  - bioconda
+  - nodefaults
+  - https://repo.anaconda.com/pkgs/main
+  - https://repo.anaconda.com/pkgs/r
+dependencies:
+  - _libgcc_mutex=0.1=conda_forge
+  - _openmp_mutex=4.5=2_gnu
+  - bzip2=1.0.8=h4bc722e_7
+  - ca-certificates=2025.8.3=hbd8a1cb_0
+  - ld_impl_linux-64=2.44=h1423503_1
+  - libexpat=2.7.1=hecca717_0
+  - libffi=3.4.6=h2dba641_1
+  - libgcc=15.1.0=h767d61c_4
+  - libgcc-ng=15.1.0=h69a702a_4
+  - libgomp=15.1.0=h767d61c_4
+  - liblzma=5.8.1=hb9d3cd8_2
+  - libmpdec=4.0.0=hb9d3cd8_0
+  - libsqlite=3.50.4=h0c1763c_0
+  - libuuid=2.38.1=h0b41bf4_0
+  - libzlib=1.3.1=hb9d3cd8_2
+  - ncurses=6.5=h2d0b736_3
+  - openssl=3.5.2=h26f9b46_0
+  - pip=25.2=pyh145f28c_0
+  - python=3.13.5=hec9711d_102_cp313
+  - python_abi=3.13=8_cp313
+  - readline=8.2=h8c095d6_2
+  - tk=8.6.13=noxft_hd72426e_102
+  - pip:
+      - click==8.2.1
+      - contourpy==1.3.3
+      - cycler==0.12.1
+      - fonttools==4.59.0
+      - kiwisolver==1.4.9
+      - markdown-it-py==4.0.0
+      - matplotlib==3.10.5
+      - mdurl==0.1.2
+      - numpy==2.3.2
+      - packaging==25.0
+      - pandas==2.3.1
+      - pillow==11.3.0
+      - pygments==2.19.2
+      - pyparsing==3.2.3
+      - python-dateutil==2.9.0.post0
+      - pytz==2025.2
+      - rich==14.1.0
+      - rich-click==1.8.9
+      - seaborn==0.13.2
+      - six==1.17.0
+      - typing-extensions==4.14.1
+      - tzdata==2025.2
+prefix: /home/m_aglave/.environnements_conda/snakemake_benchmark_summary


### PR DESCRIPTION
**project_benchmark.py :**  
- replace mem_mb by mem_gb if mem_gb is not NaN (because if mem_gb is used in rule, mem_mb takes the default value which is wrong).
- remove duplicated describe() computation that lead to compute mean/min/max/quartiles of mean/min/max/quartiles instead of mean/min/max/quartiles of raw data.*
- bug fix if there is only one execusion of a rule (like multiqc), we can't compute std.

**project_benchmark_report.py :**
Input: benchmark.tsv from project_benchmark.py
Output: rapport_stats.html (name can be changed with option) with General statistics (Number of unique rules, Number of jobs, Total CPU time, Total IO in, Total IO out), Metrics definition, Metric summary per rule (count, mean, min, max or sum depending on the metric), Graphs per metric for all rules, and Details per rule (raw input table split by rule).